### PR TITLE
Fix order of container and volume in docker run

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -17,12 +17,12 @@ docker build -t jedie/buildozer .
 
 compile {{{kivy_hello_world}}}:
 {{{
-docker run -t jedie/buildozer -v ${PWD}/kivy_hello_world:/buildozer/ buildozer --verbose android release
+docker run -t -v ${PWD}/kivy_hello_world:/buildozer/  jedie/buildozer buildozer --verbose android release
 }}}
 
 to into bash shell:
 {{{
-docker run -it jedie/buildozer -v ${PWD}/kivy_hello_world:/buildozer/ /bin/bash
+docker run -it -v ${PWD}/kivy_hello_world:/buildozer/ jedie/buildozer /bin/bash
 }}}
 
 Example project that used this docker image is:


### PR DESCRIPTION
Fixes the error:

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"-v\": executable file not found in $PATH": unknown.
```

Solution from: https://stackoverflow.com/questions/27158840/docker-executable-file-not-found-in-path